### PR TITLE
adiconando teste ao registro de usuarios, com cadastro de varios usuarios simultaneos

### DIFF
--- a/test/rest/performance/user/registerUser.test.js
+++ b/test/rest/performance/user/registerUser.test.js
@@ -5,25 +5,19 @@ export const options = {
     stages: [
         { duration: '15s', target: 100 },
         { duration: '25s', target: 30 },
-        {duration: '10s', target: 30}
+        { duration: '10s', target: 0 }
     ],
     thresholds: {
         http_req_failed: ['rate<0.01'],
-        http_req_duration: ['p(95)<100'],
-    }
+        http_req_duration: ['p(95)<1000'],
+    },
 };
 
-export function setup() {
-    const newUser = registerUser(); 
-    return { newUser };
-}
+export default function () {
+    const newUser = registerUser(); // retorna diretamente o campo 'username' do JSON
 
-// teste principal
-export default function (data) {
-    const { newUser } = data;
-
-    check({ username: newUser }, {
-        'Usuário registrado com sucesso': (r) => r.username !== undefined
+    check(newUser, {
+        'Usuário registrado com sucesso': (u) => typeof u === 'string' && u.length > 0,
     });
 
     sleep(1);

--- a/test/rest/performance/user/registerUser.test.js
+++ b/test/rest/performance/user/registerUser.test.js
@@ -1,0 +1,30 @@
+import { check, sleep } from 'k6';
+import { registerUser } from '../../../utils/performance.js';
+
+export const options = {
+    stages: [
+        { duration: '15s', target: 100 },
+        { duration: '25s', target: 30 },
+        {duration: '10s', target: 30}
+    ],
+    thresholds: {
+        http_req_failed: ['rate<0.01'],
+        http_req_duration: ['p(95)<100'],
+    }
+};
+
+export function setup() {
+    const newUser = registerUser(); 
+    return { newUser };
+}
+
+// teste principal
+export default function (data) {
+    const { newUser } = data;
+
+    check({ username: newUser }, {
+        'Usuário registrado com sucesso': (r) => r.username !== undefined
+    });
+
+    sleep(1);
+}


### PR DESCRIPTION
Implementando testes com varios simultaneos sendo cadastrados e validando se a ação foi feita corretamente, segue evidencia do teste passando:
<img width="822" height="318" alt="image" src="https://github.com/user-attachments/assets/b21ff293-4e85-42db-805b-48d12adc8168" />
<img width="366" height="317" alt="image" src="https://github.com/user-attachments/assets/289dbaca-9a2f-44c0-b9c3-2dce9a5bfa2f" />
<img width="1308" height="588" alt="image" src="https://github.com/user-attachments/assets/e0ad00af-497f-4b4f-b317-854c5584186b" />
<img width="1326" height="595" alt="image" src="https://github.com/user-attachments/assets/b56f787a-8894-4c46-aa70-3cc6cd397536" />

